### PR TITLE
Update AZ400_M03_Sharing_Team_Knowledge_using_Azure_Project_Wikis.md

### DIFF
--- a/Instructions/Labs/AZ400_M03_Sharing_Team_Knowledge_using_Azure_Project_Wikis.md
+++ b/Instructions/Labs/AZ400_M03_Sharing_Team_Knowledge_using_Azure_Project_Wikis.md
@@ -1,7 +1,7 @@
 ---
 lab:
     title: 'Lab: Sharing Team Knowledge using Azure Project Wikis'
-    az400Module: 'Module 03: Managing Technical Debt'
+    module: 'Module 03: Managing Technical Debt'
 ---
 
 # Lab: Sharing Team Knowledge using Azure Project Wikis


### PR DESCRIPTION
The title in the table needs to be just 'module' to show on the following site https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/ 
This needs to be done in all the labs. Just say the word and I can quickly do it.

# Module: 03
## Lab/Demo: 03
