### PR TITLE
Removing the leading 0 in module number

### DIFF
--- a/Instructions/Labs/AZ400_M03_Sharing_Team_Knowledge_using_Azure_Project_Wikis.md
+++ b/Instructions/Labs/AZ400_M03_Sharing_Team_Knowledge_using_Azure_Project_Wikis.md
@@ -1,7 +1,7 @@
 ---
 lab:
     title: 'Lab: Sharing Team Knowledge using Azure Project Wikis'
-    module: 'Module 03: Managing Technical Debt'
+    module: 'Module 3: Managing Technical Debt'
 ---
 
 # Lab: Sharing Team Knowledge using Azure Project Wikis


### PR DESCRIPTION
# Module: 03

Changes proposed in this pull request:

Removed the leading 0 in module number (it's the only lab with a leading 0 shown in the overview aka.ms/az400labs)