### PR TITLE
Remove duplicate reference

### DIFF
--- a/Instructions/Labs/AZ400_M05_Configuring_Agent_Pools_and_Understanding_Pipeline_Styles.md
+++ b/Instructions/Labs/AZ400_M05_Configuring_Agent_Pools_and_Understanding_Pipeline_Styles.md
@@ -101,7 +101,6 @@ In this task, you will prepare your lab environment for deployment of an image t
 
     > **Note**: Make sure to record the personal access token at this point. You will not be able to retrieve its value once you navigate away from the current page. 
 
-1.  On the lab computer, start a web browser, navigate to [the Packer download page](https://www.packer.io/downloads), download the current version of Windows 64-bit version of Packer, open the archive containing the **packer.exe** binary, and extract it into the **C:\Windows** directory. 
 1.  On the lab computer, start Windows PowerShell ISE as administrator and, from the console pane of the **Administrator: Windows PowerShell ISE** window, run the following to install Chocolatey:
 
     ```powershell


### PR DESCRIPTION
Current instructions show installing from website, then again using chocolatey.
Removes manual download from website instruction in favour of using the chocolatey command.

# Module: 05
## Lab/Demo: 01

Changes proposed in this pull request:

- Current instruction suggest installing packer using https://www.packer.io/downloads, but then proceeds to suggest installing using chocolatey later on.
- PR Removes instruction to download using the website in favour of using chocolatey command