### PR TITLE
Correcting template name and folder

### DIFF
--- a/Instructions/Labs/AZ400_M11_Configuring_Pipelines_as_Code_with_YAML.md
+++ b/Instructions/Labs/AZ400_M11_Configuring_Pipelines_as_Code_with_YAML.md
@@ -53,7 +53,7 @@ In this exercise, you will set up the prerequisites for the lab, which consist o
 
 #### Task 1: Configure the team project
 
-In this task, you will use Azure DevOps Demo Generator to generate a new project based on the **Parts Unlimited** template.
+In this task, you will use Azure DevOps Demo Generator to generate a new project based on the **PartsUnlimited-YAML** template.
 
 1.  On your lab computer, start a web browser and navigate to [Azure DevOps Demo Generator](https://azuredevopsdemogenerator.azurewebsites.net). This utility site will automate the process of creating a new Azure DevOps project within your account that is prepopulated with content (work items, repos, etc.) required for the lab. 
 
@@ -62,7 +62,7 @@ In this task, you will use Azure DevOps Demo Generator to generate a new project
 1.  Click **Sign in** and sign in using the Microsoft account associated with your Azure DevOps subscription.
 1.  If required, on the **Azure DevOps Demo Generator** page, click **Accept** to accept the permission requests for accessing your Azure DevOps subscription.
 1.  On the **Create New Project** page, in the **New Project Name** textbox, type **Configuring Pipelines as Code with YAML**, in the **Select organization** dropdown list, select your Azure DevOps organization, and then click **Choose template**.
-1.  In the list of templates, in the toolbar, click **DevOps Labs**, select the **PartsUnlimited-YAML** template and click **Select Template**.
+1.  In the list of templates, in the toolbar, click **General**, select the **PartsUnlimited-YAML** template and click **Select Template**.
 1.  Back on the **Create New Project** page, click **Create Project**
 
     > **Note**: Wait for the process to complete. This should take about 2 minutes. In case the process fails, navigate to your DevOps organization, delete the project, and try again.


### PR DESCRIPTION
# Module: 11
## Lab: 11.1

Fixes 2.

Changes proposed in this pull request:

- Template name is PartsUnlimited-YAML
- Category where the template is located is General not DevOps Labs