### PR TITLE
fix --> azure devops org instead of devops org

### DIFF
--- a/Instructions/Labs/AZ400_M03_Sharing_Team_Knowledge_using_Azure_Project_Wikis.md
+++ b/Instructions/Labs/AZ400_M03_Sharing_Team_Knowledge_using_Azure_Project_Wikis.md
@@ -62,7 +62,7 @@ In this task, you will use Azure DevOps Demo Generator to generate a new project
 1.  In the list of templates, select the **Tailwind Traders** template and click **Select Template**.
 1.  Back on the **Create New Project** page, if prompted to install a missing extension, select the checkbox below the **ARM Outputs** and click **Create Project**.
 
-    > **Note**: Wait for the process to complete. This should take about 2 minutes. In case the process fails, navigate to your DevOps organization, delete the project, and try again.
+    > **Note**: Wait for the process to complete. This should take about 2 minutes. In case the process fails, navigate to your Azure DevOps organization, delete the project, and try again.
 
 1.  On the **Create New Project** page, click **Navigate to project**.
 


### PR DESCRIPTION
# Module: 3
## Lab/Demo: Sharing Team Knowledge using Azure Project Wikis

Fixes #58 .

Changes proposed in this pull request:

devops org --> Azure DevOps organization