### PR TITLE
lab 19: clarify setup location for whitesource extension

### DIFF
--- a/Instructions/Labs/AZ400_M19_Implement_Security_and_Compliance_in_an_Azure_DevOps_pipeline.md
+++ b/Instructions/Labs/AZ400_M19_Implement_Security_and_Compliance_in_an_Azure_DevOps_pipeline.md
@@ -84,7 +84,7 @@ In this exercise, leverage WhiteSource Bolt to scan the project code for securit
 
 In this task, you will activate WhiteSource Bolt in the newly generated Azure Devops project.
 
-1.  On your lab computer, in the web browser window displaying the Azure DevOps portal with the **WhiteSource Bolt** project open, in the vertical menu bar at the far left of the Azure DevOps portal, click **Pipelines** and, in the **Pipelines** section, click **WhiteSource Bolt**.
+1.  On your lab computer, in the web browser window displaying the Azure DevOps portal with the **WhiteSource Bolt** project open, **in the vertical menu bar** at the far left of the Azure DevOps portal, click **Pipelines**  section and  **WhiteSource Bolt** option (in the vertical menu bar under "Deployment Groups" option).
 1.  On the **You're almost there** pane, provide your **Work Email** and **Company Name**, in the **Country** dropdown list, select the entry representing your country, and click *Get Started* button to start using the *Free* version of WhiteSource Bolt. This will automatically open a new browser tab displaying the **Get Started With Bolt** page. 
 1.  Switch back to the web browser tab displaying the Azure DevOps portal and verify that the **You are using a FREE version of WhiteSource Bolt** is displayed.
 


### PR DESCRIPTION

# Module: 19
## Lab/Demo: 19

Fixes # .

Changes proposed in this pull request:

- Clarify as people usually go to Pipelines>pipeline and oipen the actual pipeline called whitesource
- 
-