### PR TITLE
Module 10 missing instructions

### DIFF
--- a/Instructions/Labs/AZ400_M10_Creating_a_Release_Dashboard.md
+++ b/Instructions/Labs/AZ400_M10_Creating_a_Release_Dashboard.md
@@ -60,9 +60,9 @@ In this task, you will create an Azure DevOps Starter resource in your Azure sub
 
 1.  On your lab computer, start a web browser, navigate to the [**Azure Portal**](https://portal.azure.com) and sign in with the user account that has the Owner or Contributor role in the Azure subscription you will be using in this lab.
 1.  In the Azure portal, search for and select the **DevOps Starter** resource type and, on the **DevOps Starter** blade, click **+ Add**. 
-1.  On the **DevOps Starter** blade, on the **Start fresh with a new application** pane, select the **.NET** tile and click **Next**. 
-1.  On the **DevOps Starter** blade, on the **Choose an application framework** pane, select the **ASP<nolink>.NET Core** tile, move the **Add a database** slider to the **On** position, and click **Next**. 
-1.  On the **DevOps Starter** blade, on the **Select an Azure service to deploy the application** pane, ensure that the **Windows Web App** tile is selected and click **Next**. 
+1.  On the **DevOps Starter** blade, on the **Start fresh with a new application** pane, select the **.NET** tile and on the tops next to Setting up DevOps starter with GitHub, change settings, click **here** and select **Azure DevOps** , **Done** and **Next: Framework >**. 
+1.  On the **DevOps Starter** blade, on the **Choose an application framework** pane, select the **ASP<nolink>.NET Core** tile, move the **Add a database** slider to the **On** position, and click **Next: Service >**. 
+1.  On the **DevOps Starter** blade, on the **Select an Azure service to deploy the application** pane, ensure that the **Windows Web App** tile is selected and click **Next: Create >**. 
 1.  On the **DevOps Starter** blade, on the **Almost there** pane, specify the following settings:
 
     | Setting | Value |
@@ -87,7 +87,7 @@ In this task, you will create an Azure DevOps Starter resource in your Azure sub
     | Location | the name of the same Azure region that you chose for the location of the Azure web app |
     | Database Name | **az400m10l02-db** |
 
-1.  Back on the **DevOps Starter** blade, on the **Almost there** pane, click **Done**.
+1.  Back on the **DevOps Starter** blade, on the **Almost there** pane, click **Done** and then **Review+Create**.
 
     > **Note**: Wait for the deployment to complete. The provisioning of the **DevOps Starter** resource should take about 2 minutes.
 


### PR DESCRIPTION
I added some details required to complete Task 1 correctly, otherwise by default the DevOps Starter will use GitHub and the instructions will be completely different.
It's important to make sure ADO is used for the DevOps Starter.

# Module: 10 
## Lab: Creating a Release Dashboard

Fixes # Added details to select Azure DevOps for the Starter, otherwise GitHub is used by default

Changes proposed in this pull request:

- Extra details to select the proper option and make sure Azure DevOps is selected on the Starter
- Missing names from the options like Review+Create
