### PR TITLE
Fix deploy button that wasn't leading to anywhere lab 11

### DIFF
--- a/Instructions/Labs/AZ400_M11_Setting_Up_and_Running_Functional_Tests.md
+++ b/Instructions/Labs/AZ400_M11_Setting_Up_and_Running_Functional_Tests.md
@@ -78,7 +78,7 @@ In this task, you will use Azure DevOps Demo Generator to generate a new project
 
 In this task, you will provision an Azure VM running Windows Server 2016 along with SQL Express 2017, Chrome, and Firefox.
 
-1.  Click on the deploy to Azure button. [![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FMicrosoft%2Falmvm%2Fmaster%2Flabs%2Fvstsextend%2Fselenium%2Farmtemplate%2Fazuredeploy.json) This will automatically redirect you to the **Custom deployment** blade in the Azure portal.
+1.  Click on the deploy to Azure button. [![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FMicrosoft%2Falmvm%2Fmaster%2Flabs%2Fvstsextend%2Fselenium%2Farmtemplate%2Fazuredeploy.json)  This will automatically redirect you to the **Custom deployment** blade in the Azure portal.
 1.  If prompted, sign in with the user account that has the Owner role in the Azure subscription you will be using in this lab and has the role of the Global Administrator in the Azure AD tenant associated with this subscription.
 1.  On the **Custom deployment** blade, specify the following settings:
 


### PR DESCRIPTION
# Module: 11
## Lab: 11

Fixes # .

In Lab 11 - Setting Up and Running Functional Tests (second lab), under  Task 2: Create Azure resources 
There is a button that allow the student to deploy to azure, the button doesn't work. 


Changes proposed in this pull request:
Fixed the button with the right link that redirects to the right place and allow the deployment of this environment. 

-
-
-