### PR TITLE
Eliminate extra "the" from the Branch pane explanation

### DIFF
--- a/Instructions/Labs/AZ400_M02_Version_Controlling_with_Git_in_Azure_Repos.md
+++ b/Instructions/Labs/AZ400_M02_Version_Controlling_with_Git_in_Azure_Repos.md
@@ -231,7 +231,7 @@ In this task, you will step through commit history by using the Azure DevOps por
 
 In this exercise, you will step through scenarios that involve branch management by using Visual Studio Code and the Azure DevOps portal.
 
-You can manage the in your Azure DevOps Git repo from the **Branches** view of **Azure Repos** in the Azure DevOps portal. You can also customize the view to track the branches you care most about so you can stay on top of changes made by your team.
+You can manage in your Azure DevOps Git repo from the **Branches** view of **Azure Repos** in the Azure DevOps portal. You can also customize the view to track the branches you care most about so you can stay on top of changes made by your team.
 
 Committing changes to a branch will not affect other branches and you can share branches with others without having to merge the changes into the main project. You can also create new branches to isolate changes for a feature or a bug fix from your master branch and other work. Since the branches are lightweight, switching between branches is quick and easy. Git does not create multiple copies of your source when working with branches, but rather uses the history information stored in commits to recreate the files on a branch when you start working on it. Your Git workflow should create and use branches for managing features and bugfixes. The rest of the Git workflow, such as sharing code and reviewing code with pull requests, all work through branches. Isolating work in branches makes it very simple to change what you are working on by simply changing your current branch.
 


### PR DESCRIPTION
# Module: 00
## Lab/Demo: 00

Fixes # There is an extra "the" in the description of the Branches section

Changes proposed in this pull request:
Eliminate the extra "the" from the affected paragraph