### PR TITLE
Update Lab 7 instructions to delete ALL resource groups created

### DIFF
--- a/Instructions/Labs/AZ400_M07_Integrating_Azure_Key_Vault_with_Azure_DevOps.md
+++ b/Instructions/Labs/AZ400_M07_Integrating_Azure_Key_Vault_with_Azure_DevOps.md
@@ -239,7 +239,18 @@ In this task, you will use Azure Cloud Shell to remove the Azure resources provi
     az group list --query "[?starts_with(name,'az400m07l01-RG')].[name]" --output tsv | xargs -L1 bash -c 'az group delete --name $0 --no-wait --yes'
     ```
 
-    >**Note**: The command executes asynchronously (as determined by the --nowait parameter), so while you will be able to run another Azure CLI command immediately afterwards within the same Bash session, it will take a few minutes before the resource groups are actually removed.
+1.  List the resource group that was created by the pipeline.
+
+    ```sh
+    az group list --query "[?starts_with(name,'azurekeyvaultlab')].name" --output tsv
+    ```
+1.  Delete all resource group created by the pipeline:
+
+    ```sh
+    az group list --query "[?starts_with(name,'azurekeyvaultlab')].[name]" --output tsv | xargs -L1 bash -c 'az group delete --name $0 --no-wait --yes'
+    ```
+    
+   >**Note**: The delete commands execute asynchronously (as determined by the --nowait parameter), so while you will be able to run another Azure CLI command immediately afterwards within the same Bash session, it will take a few minutes before the resource groups are actually removed.
 
 #### Review
 


### PR DESCRIPTION
# Module: 07

## Lab 07

Changes proposed in this pull request:

The student creates a resource group named az400m07l01-RG. The lab instructions correctly delete the resource group. 
But when students run the pipeline, an additional resource group is created named 'azurekeyvaultlab.' It contains the web app and a database. This is not deleted in the instructions.  

This commit mimics the original delete steps to remove the extra resource group.