### PR TITLE
Issue-M11-LabA:Simplifying lab 11A's instructions

### DIFF
--- a/Instructions/Labs/AZ400_M11_Configuring_Pipelines_as_Code_with_YAML.md
+++ b/Instructions/Labs/AZ400_M11_Configuring_Pipelines_as_Code_with_YAML.md
@@ -74,43 +74,80 @@ In this task, you will use Azure DevOps Demo Generator to generate a new project
 In this task, you will create an Azure web app and an Azure SQL database by using the Azure portal.
 
 1.  From the lab computer, start a web browser, navigate to the [**Azure Portal**](https://portal.azure.com), and sign in with the user account that has the Owner role in the Azure subscription you will be using in this lab and has the role of the Global Administrator in the Azure AD tenant associated with this subscription.
-1.  In the Azure portal, click the icon consisting of three horizontal lines in the upper left corner of the page and, in the hub menu and click **+ Create a resource**.
-1.  On the **New** blade, in the search text box, type **Web App + SQL** and press the **Enter** key.
-1.  On the **Web App + SQL**, click **Create**.
-1.  On the **Web App + SQL** blade, specify the following settings:
+1.  In the Azure portal, in the toolbar, click the **Cloud Shell** icon located directly to the right of the search text box.
+1.  If prompted to select either **Bash** or **PowerShell**, select **Bash**.
 
-    | Setting | Value |
-    | --- | --- |
-    | App name | any valid, globally unique DNS host name |
-    | Subscription | the name of the Azure subscription you are using in this lab |
-    | Resource group | the name of a new resource group **az400m11l01-RG** |
+    >**Note**: If this is the first time you are starting **Cloud Shell** and you are presented with the **You have no storage mounted** message, select the subscription you are using in this lab, and select **Create storage**. 
 
-1.  Click **App Service plan/Location**, on the **App Service plan** blade, click **+ Create new**.
-1.  On the **New App Service Plan** blade, specify the following settings and click **OK**:
+1.  From the **Bash** prompt, in the **Cloud Shell** pane, run the following command to create a resource group (replace the `<region>` placeholder with the name of the Azure region closest to you such as 'eastus').
 
-    | Setting | Value |
-    | --- | --- |
-    | App service plan | any valid name |
-    | Location| the name of the Azure region where you want to deploy resources you will be using in this lab |
-    | Pricing tier | **D1 Shared** |
+```bash
+RESOURCEGROUPNAME='az400m11l01-RG'
+LOCATION='<region>'
+az group create -n $RESOURCEGROUPNAME -l $LOCATION
+```
 
-1.  Back on the **Web App + SQL** blade, click **SQL Database**.
-1.  On the **SQL Database** blade, in the **Name** textbox, type **partsunlimited**.
-1.  On the **SQL Database** blade, click **Target server**.
-1.  On the **New server** blade, specify the following settings and click **Select**:
+1.  To create a Windows App service plan by running the following command:
 
-    | Setting | Value |
-    | --- | --- |
-    | Server name | any valid, globally unique DNS host name |
-    | Server admin login | Student |
-    | Password | Pa55w.rd1234 |
-    | Location | the name of the Azure region that you chose for the App Service plan |
-    | Allow Azure services to access server | enabled |
+```bash
+SERVICEPLANNAME='az400l11a-sp1'
+az appservice plan create -g $RESOURCEGROUPNAME -n $SERVICEPLANNAME --sku S1
+```
+> **Note**: If the `az appservice plan create` command fails with an error message starting with `ModuleNotFoundError: No module named 'vsts_cd_manager'`, then run the following commands and then re-run the failed command.
 
-1.  Back on the **SQL Database** blade, click **Select**.
-1.  Back on the **Web App + SQL** blade, click **Create**. 
+```bash
+az extension remove -n appservice-kube
+az extension add --yes --source "https://aka.ms/appsvc/appservice_kube-latest-py2.py3-none-any.whl"
+```
 
-    > **Note**: Wait for the process to complete. This should take about 2 minutes. 
+1.  Create a web app with a unique name.
+
+```bash
+WEBAPPNAME=partsunlimited$RANDOM$RANDOM
+az webapp create -g $RESOURCEGROUPNAME -p $SERVICEPLANNAME -n $WEBAPPNAME
+```
+
+> **Note**: Record the name of the web app. You will need it later in this lab.
+
+1.  Next, create an Azure SQL Server.
+
+```bash
+USERNAME="Student"
+SQLSERVERPASSWORD="Pa55w.rd1234"
+SERVERNAME="partsunlimitedserver$RANDOM"
+
+az sql server create --name $SERVERNAME --resource-group $RESOURCEGROUPNAME \
+--location $LOCATION --admin-user $USERNAME --admin-password $SQLSERVERPASSWORD
+```
+
+1.  The web app needs to be able to access the SQL server, so we need to allow access to Azure resources in the SQL Server firewall rules.
+
+```bash
+STARTIP="0.0.0.0"
+ENDIP="0.0.0.0"
+az sql server firewall-rule create --server $SERVERNAME --resource-group $RESOURCEGROUPNAME \
+--name AllowAzureResources --start-ip-address $STARTIP --end-ip-address $ENDIP
+```
+
+1.  Now create a database within that server.
+
+```bash
+az sql db create --server $SERVERNAME --resource-group $RESOURCEGROUPNAME --name PartsUnlimited \
+--service-objective S0
+```
+
+1.  The web app you created needs the database connection string in its configuration, so run the following commands to prepare and add it to the app settings of the web app.
+
+```bash
+CONNSTRING=$(az sql db show-connection-string --name PartsUnlimited --server $SERVERNAME \
+--client ado.net --output tsv)
+
+CONNSTRING=${CONNSTRING//<username>/$USERNAME}
+CONNSTRING=${CONNSTRING//<password>/$SQLSERVERPASSWORD}
+
+az webapp config connection-string set --name $WEBAPPNAME --resource-group $RESOURCEGROUPNAME \
+-t SQLAzure --settings "DefaultConnectionString=$CONNSTRING" 
+```
 
 ### Exercise 1: Configure CI/CD Pipelines as Code with YAML in Azure DevOps
 
@@ -312,13 +349,6 @@ In this task, you will add continuous delivery to the YAML-based definition of t
 #### Task 4: Review the deployed site
 
 1.  Switch back to web browser window displaying the Azure portal and navigate to the blade displaying the properties of the Azure web app.
-1.  On the Azure web app blade, in the **Settings** section, select **Configuration**.
-1.  On the Azure web app configuration blade, in the **Connection strings** section, click the **defaultConnection** entry.
-1.  On the **Add/Edit connection string** blade, in the **Name** textbox, change the current value to **DefaultConnectionString**, which is the key expected by the application, and click **OK**.
-
-    > **Note**: This will enable the application to connect to the database created for the app service. 
-
-1.  Back on the Azure web app configuration blade, click **Save** to apply the changes and, when prompted, click **Continue**
 1.  On the Azure web app blade, click **Overview** and, on the overview blade, click **Browse** to open your site in a new web browser tab.
 1.  Verify that the deployed site loads as expected in the new browser tab.
 


### PR DESCRIPTION
Removed the reference to the resource creation from portal and replaced it with Azure CLI commands. This will simplify the deployment since the old `WebApp + SQL` is now removed from the portal and students cannot deploy the web app to a Linux based app which is created by choosing `WebApp + Database` option.

## Related Issue

Fixes #113 

## Checklist 
Mark completed with "x" between brackets, "[x]":
- [x] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#reporting-issues) 📝
- [x] Tested it
- [x] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝

Changes proposed in this pull request:

- Removed the old steps to create web app and sql server from Azure portal
- Added steps using cloud shell and Azure CLI to create the web app, sql server, and database and inject the connection string into the web app's connection strings.
