### PR TITLE
Addin part to install VSCode on remote VM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .vscode/settings.json
+Instructions/.DS_Store
+Instructions/Labs/.DS_Store

--- a/Instructions/Labs/AZ400_M14_Ansible_with_Azure.md
+++ b/Instructions/Labs/AZ400_M14_Ansible_with_Azure.md
@@ -134,6 +134,25 @@ In this task, you will install and configure Ansible on the Azure VM you deploye
     ```bash
     sudo apt-get update
     ```
+1.  Run the following commends to add and install VSCode (whenever you are prompted for confirmation, type **y** and press the **Enter** key):
+    ```
+    sudo apt-get install wget
+    ```
+    ```
+    wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > packages.microsoft.gpg
+    ```
+    ```
+    sudo install -o root -g root -m 644 packages.microsoft.gpg /etc/apt/trusted.gpg.d/
+    sudo sh -c 'echo "deb [arch=amd64,arm64,armhf signed-by=/etc/apt/trusted.gpg.d/packages.microsoft.gpg] https://packages.microsoft.com/repos/code stable main" > /etc/apt/sources.list.d/vscode.list'
+    ```
+    ```
+    rm -f packages.microsoft.gpg
+    ```
+    ```
+    sudo apt update
+    sudo apt install apt-transport-https
+    sudo apt install code
+    ```
 
 1.  Run the following to install Ansible and the required Azure modules (**make sure that you run the commands individually, line by line**, and, whenever you are prompted for confirmation, type **y** and press the **Enter** key):
 


### PR DESCRIPTION


**Replace issue name M14-LAB14a:
In the lab the students are required to use VSCode but
it's not installed, so I added a part to install it so
the students can follow the steps without getting stuck

## Related Issue

**Link related Github Issue** 🢂 Fixes # . (Include issue number after #)

## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [ ] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#reporting-issues) 📝
- [X] Tested it
- [X] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝

Changes proposed in this pull request:

- Adding step to install VSCode on Ubuntu followed by this [guide](https://code.visualstudio.com/docs/setup/linux) which is the must generic and worked on both Ubuntu 18 and 20 


