### PR TITLE
LAB 16 - EX 01 - TASK 02 - STEP 25

### DIFF
--- a/Instructions/Labs/AZ400_M16_Deploying_multi-container_application_to_Azure_Kubernetes_Services.md
+++ b/Instructions/Labs/AZ400_M16_Deploying_multi-container_application_to_Azure_Kubernetes_Services.md
@@ -238,7 +238,8 @@ In this task, you will configure the build and release pipelines in the Azure De
 
 1.  On the **Tasks** pane of the **Dev** stage of the **MyHealth.AKS.Release** release pipeline, click the **Variables** tab. 
 1.  In the list of the **Pipeline variables**, update the value of the **ACR** variable to the Azure Container Registry name you recorded at the end of the previous task. 
-1.  In the list of the **Pipeline variables**, update the values of the **SQLserver** variable to the name of the logical server you recorded at the end of the previous task (SQLPassword is **P2ssw0rd1234**, SQLuser is **sqladmin**). 
+1.  In the list of the **Pipeline variables**, update the values of the **SQLserver** variable to the name of the logical server you recorded at the end of the previous task (SQLPassword is **P2ssw0rd1234**, SQLuser is **sqladmin**, DatabaseName is **mhcdb**). 
+
 1.  In the upper right corner of the **All pipelines / MyHealth.AKS.Release** pane, click **Save**, and, when prompted, click **Save** again to save the changes.
 
     >**Note**: In the list of pipeline variables, **DatabaseName** is set to **mhcdb**, **SQLuser** is set to **sqladmin**, and **SQLpassword** is set to **P2ssw0rd1234**. If you entered different values when creating the Azure SQL database earlier in this lab, update the values of the variables accordingly.

--- a/Instructions/Labs/AZ400_M16_Deploying_multi-container_application_to_Azure_Kubernetes_Services.md
+++ b/Instructions/Labs/AZ400_M16_Deploying_multi-container_application_to_Azure_Kubernetes_Services.md
@@ -238,7 +238,7 @@ In this task, you will configure the build and release pipelines in the Azure De
 
 1.  On the **Tasks** pane of the **Dev** stage of the **MyHealth.AKS.Release** release pipeline, click the **Variables** tab. 
 1.  In the list of the **Pipeline variables**, update the value of the **ACR** variable to the Azure Container Registry name you recorded at the end of the previous task. 
-1.  In the list of the **Pipeline variables**, update the values of the **SQLserver** variable to the name of the logical server you recorded at the end of the previous task (SQLPassword is **P2ssw0rd1234**, SQLuser is **sqladmin**, SQLdatabase is **mhcdb**). 
+1.  In the list of the **Pipeline variables**, update the values of the **SQLserver** variable to the name of the logical server you recorded at the end of the previous task (SQLPassword is **P2ssw0rd1234**, SQLuser is **sqladmin**). 
 1.  In the upper right corner of the **All pipelines / MyHealth.AKS.Release** pane, click **Save**, and, when prompted, click **Save** again to save the changes.
 
     >**Note**: In the list of pipeline variables, **DatabaseName** is set to **mhcdb**, **SQLuser** is set to **sqladmin**, and **SQLpassword** is set to **P2ssw0rd1234**. If you entered different values when creating the Azure SQL database earlier in this lab, update the values of the variables accordingly.


### PR DESCRIPTION
The variable "SQLdatabase" doesn't exist in the pipeline variables set.

Changes proposed in this pull request:

- I Removed the variable called "SQLdatabase" in the instructions because that variable doesn't exist in the variable set of the pipeline
- The appsettings.json file in the MyHealt.Web code has the name of the SQL Database in the connection string and it isn't changed by the first task of the pipeline.
