### PR TITLE
M11-L11b: remove the "remove installer section"

### DIFF
--- a/Allfiles/Labs/11b/chrome_firefox_VSTSagent_IIS.ps1
+++ b/Allfiles/Labs/11b/chrome_firefox_VSTSagent_IIS.ps1
@@ -63,9 +63,5 @@ Start-Process -FilePath "$workdir\firefox.exe" -ArgumentList "/S"
 
 Start-Sleep -s 35
 
-# Remove the installer
-
-rm -Force $workdir\firefox*
-
 #copy geckodriver
 Invoke-WebRequest https://github.com/Microsoft/almvm/blob/master/labs/vstsextend/selenium/armtemplate/geckodriver.exe?raw=true -OutFile "C:\Program Files\Mozilla Firefox\geckodriver.exe"


### PR DESCRIPTION
In my first try, the whole deployment failed because of this code. Azure deployment portal shown the fail log as "deny to remove this path, row 68, blablabla...", I guess it maybe because the Firefox installation hasn't finished yet even after 35s sleep.

You know deployment takes 15mins waiting ha. After removed this code and tried again, deployment success.

Suggest to take this code away, just keep installer as it is. We usually remove the Lab VM after the exercise.

