### PR TITLE
[Proposal]-[M03]-[Lab 07]:[Prevent a new organization from being created]

### DIFF
--- a/Instructions/Labs/AZ400_M03_Integrating_External_Source_Control_with_Azure_Pipelines.md
+++ b/Instructions/Labs/AZ400_M03_Integrating_External_Source_Control_with_Azure_Pipelines.md
@@ -79,7 +79,7 @@ In this task, you will fork a GitHub repo and install Azure Pipelines in your Gi
     > **Note**: You have the option to specify repositories to include, but for the purposes of this lab, just include all of them. Note that Azure DevOps requires the listed set of permissions to fulfill its services. 
 
 7.  If prompted, authenticate with your GitHub password to continue.
-8.  When prompted, on the **Setup your Azure Pipelines project** page, in the **Select your Azure DevOps organization** dropdown list, select your Azure DevOps account and click **Create a new project**.
+8.  When prompted, on the **Setup your Azure Pipelines project** page, firstly, click **Switch Directories** and ensure 'Default Directory' is selected. Then, in the **Select your Azure DevOps organization** dropdown list, select your Azure DevOps account and click **Create a new project**.
 9.  When prompted, on the **Setup your Azure Pipelines project** page, in the **Project name** textbox, type **Integrating External Source Control with Azure Pipelines**, leave the **Project visibility** set to **Private**, and click **Continue**.
 10. On the **Azure Pipelines by Microsoft would like permission to** page, click **Authorize Azure Pipelines**.
 


### PR DESCRIPTION
Often students will accidently create a new organization while completing the **Integrating External Source Control with Azure Pipelines** lab. This fix adds a step to ensure that the Default Directory is selected, allowing learners to select their existing org instead of creating a new one.



## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [x] Has related GitHub Issue 💥 #231 
- [x] Tested it
- [x] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝

Changes proposed in this pull request:

-This adds a simple clarification. Often the GitHub tool will select the student's Microsoft Account directory
-
-
