### PR TITLE
M05-LAB12: Service Principal creation failure

### DIFF
--- a/Instructions/Labs/AZ400_M05_Integrating_Azure_Key_Vault_with_Azure_DevOps.md
+++ b/Instructions/Labs/AZ400_M05_Integrating_Azure_Key_Vault_with_Azure_DevOps.md
@@ -104,7 +104,8 @@ A service principal is automatically created by Azure Pipeline when you connect 
 1.  From the **Bash** prompt, in the **Cloud Shell** pane, run the following command to create a service principal (replace the `<service-principal-name>` with any unique string of characters consisting of letters and digits):
 
     ```
-    az ad sp create-for-rbac --name <service-principal-name> --role Contributor
+    SUB_ID=$(az account show --query id --output tsv)
+    az ad sp create-for-rbac --name <service-principal-name> --role contributor --scope /subscriptions/$SUB_ID
     ```
 
     > **Note**: The command will generate a JSON output. Copy the output to text file. You will need it later in this lab.


### PR DESCRIPTION
Current version of az cli requires a scope to be included when a role is specified

## Related Issue

**Link related GitHub Issue** 🢂 Fixes #232

## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [x] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#reporting-issues) 📝
- [x] Tested it
- [x] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝

## Changes proposed in this pull request:

this replacing the service principal bash creation script with one that looks up the subscription and sets the scope to be the entire subscription which WAS the default before the AZ CLI update.

