### PR TITLE
Lab10: Last step of task should reference Release-3 not Release-2

### DIFF
--- a/Instructions/Labs/AZ400_M04_L10_Creating_a_Release_Dashboard.md
+++ b/Instructions/Labs/AZ400_M04_L10_Creating_a_Release_Dashboard.md
@@ -102,7 +102,7 @@ In this task, you will create several Azure DevOps releases, including one that 
 1. In the Azure DevOps portal, in the vertical navigational pane on the left side, click **Pipelines**.
 1. On the **Recent** tab of the **Pipelines** pane, click the **az400m10l02-CI** entry, on the **Runs** tab of the **az400m10l02-CI** pane, select the most recent run, on the **Summary** tab of the run, in the **Jobs** section, click **Build** and monitor the job until its successful completion.
 1. Once the job completes, in the Azure DevOps portal, in the vertical navigational pane on the left side, in the **Pipelines** section, click **Releases**.
-1. On the **az400m10l02 - CD** pane, on the **Releases** tab, click the **Release-2** entry, on the **Pipeline** tab of the **Release-2** pane click the **dev** stage, on the **dev** pane, click **View logs**, and monitor progress of the deployment until its failure during the **Test Assemblies** stage.
+1. On the **az400m10l02 - CD** pane, on the **Releases** tab, click the **Release-3** entry, on the **Pipeline** tab of the **Release-3** pane click the **dev** stage, on the **dev** pane, click **View logs**, and monitor progress of the deployment until its failure during the **Test Assemblies** stage.
 
 #### Task 3: Create an Azure DevOps release dashboard
 


### PR DESCRIPTION
In Lab 10: Creating a Release Dashboard
The last step of Exercise 1, Task 2 should reference Release-3, not Release-2.

![image](https://user-images.githubusercontent.com/35724907/174000279-c8de30e7-c8f3-4496-b646-c5e5cb335c45.png)


## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [ ] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#reporting-issues) 📝
- [ ] Tested it
- [x] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝

Changes proposed in this pull request:

- change Release-2 to Release-3 in Exercise 1, Task 2, step 13
-
-
