### PR TITLE
LAB09: typo "clikc" on lab instruction

### DIFF
--- a/Instructions/Labs/AZ400_M04_L09_Controlling_Deployments_using_Release_Gates.md
+++ b/Instructions/Labs/AZ400_M04_L09_Controlling_Deployments_using_Release_Gates.md
@@ -145,7 +145,7 @@ In this task, you will create two Azure web apps representing the **Canary** and
 
     > **Note**: The rule will generate an alert whenever the number of failed requests is greater than 0 within the last 5 minutes.
 
-1.  Back on the **Create alert rule** pane, go to  **Details** specify the following settings and fill in information  (leave others with their default values)and clikc **Review + Create>Create**:
+1.  Back on the **Create alert rule** pane, go to  **Details** specify the following settings and fill in information  (leave others with their default values)and click **Review + Create>Create**:
 
     | Setting | Value |
     | --- | --- |


### PR DESCRIPTION
EX0 - TASK 03 - STEP 16 - There is a typo, the word "clikc" is wrong

## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [ ] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#reporting-issues) 📝
- [X] Tested it
- [X] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝

Changes proposed in this pull request:
Change the word "clikc" with the right one "click"
