### PR TITLE
Update AZ400_M01_L01_Agile_Planning_and_Portfolio_Management_with_Azu…

### DIFF
--- a/Instructions/Labs/AZ400_M01_L01_Agile_Planning_and_Portfolio_Management_with_Azure_Boards.md
+++ b/Instructions/Labs/AZ400_M01_L01_Agile_Planning_and_Portfolio_Management_with_Azure_Boards.md
@@ -210,7 +210,9 @@ Work items play a prominent role in Azure DevOps. Whether describing work to be 
 
     ![Click on "+" to create Task](images/m1/new_task_v1.png)
 
-1. At the top of the **NEW TASK** panel, in the **Enter title** textbox, type **Add page for most recent tutorials**.
+1. At the top of the **NEW TASK** panel, in the **Enter title** textbox, type **
+
+s**.
 1. On the **NEW TASK** panel, in the **Remaining Work** textbox, type **5**.
 1. On the **NEW TASK** panel, in the **Activity** dropdown list, select **Development**.
 1. On the **NEW TASK** panel, click **Save & Close**.
@@ -237,9 +239,6 @@ The sprint backlog should contain all the information the team needs to successf
     > **Note**: The current sprint has a pretty limited scope. There are two tasks in the **To do** stage. At this point, neither task has been assigned. Both show a numeric value to the right of **Unassigned** entry representing the remaining work estimate.
 
 1.  In the rectangle representing the **Add page for most recent tutorials**, click the **Unassigned** entry and, in the list of user accounts, select your account to assign the task to yourself.
-1.  Assign the **Add page for most recent tutorial** task to yourself.
-
-    > **Note**: This automatically updates the **Work By: Assigned To** section of the **Work details** pane.
 
 1. Select the **Capacity** tab of the **Sprints** view.
 

--- a/Instructions/Labs/AZ400_M01_L01_Agile_Planning_and_Portfolio_Management_with_Azure_Boards.md
+++ b/Instructions/Labs/AZ400_M01_L01_Agile_Planning_and_Portfolio_Management_with_Azure_Boards.md
@@ -210,9 +210,7 @@ Work items play a prominent role in Azure DevOps. Whether describing work to be 
 
     ![Click on "+" to create Task](images/m1/new_task_v1.png)
 
-1. At the top of the **NEW TASK** panel, in the **Enter title** textbox, type **
-
-s**.
+1. At the top of the **NEW TASK** panel, in the **Enter title** textbox, type **Add page for most recent tutorials**.
 1. On the **NEW TASK** panel, in the **Remaining Work** textbox, type **5**.
 1. On the **NEW TASK** panel, in the **Activity** dropdown list, select **Development**.
 1. On the **NEW TASK** panel, click **Save & Close**.


### PR DESCRIPTION
…re_Boards.md

In the previous line, we tell the learners to assign it to themselves - not sure why this is in there twice. If there is a reason it is in there twice, we need to change it to say: "Add page for most recent tutorials" and not "Add page for most recent tutorial"

**Replace issue name LAB00:QUICK_DESCRIPTION, for example "LAB01: My new issue" (or same name as linked Issue)**

## Related Issue

**Link related Github Issue** 🢂 Fixes # . (Include issue number after #)

## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [ ] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#reporting-issues) 📝
- [ ] Tested it
- [ ] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝

Changes proposed in this pull request:

-
-
-
