### PR TITLE
Changing signal name

### DIFF
--- a/Instructions/Labs/AZ400_M04_L09_Controlling_Deployments_using_Release_Gates.md
+++ b/Instructions/Labs/AZ400_M04_L09_Controlling_Deployments_using_Release_Gates.md
@@ -146,7 +146,7 @@ In this task, you will create two Azure web apps representing the **Canary** and
     > **Note**: You will create monitor alerts here, which you will use in later part of this lab.
 1. From the same **Settings** / **Application Insights** menu option, select **View Application Insight Data**. This redirects you to the Application Insights blade in the Azure Portal.
 1.  On the Application Insights resource blade, in the **Monitoring** section, click **Alerts** and then click **Create > Alert rule**.
-1.  On the **Select a signal** blade, in the **Search by signal name** textbox, type **Failed Requests** and select it. 
+1.  On the **Select a signal** blade, in the **Search by signal name** textbox, type **Requests** and select it. 
 1.  On the **Create an Alert Rule** blade, in the **Condition** section, leave the **Threshold** set to **Static**, validate the other default settings as follows:
 - Aggregation Type: Count
 - Operator: Greater Than


### PR DESCRIPTION
Changing signal name from **Failed Requests**  to **Requests** because failed requests doesn't exist.

No affect to the further process of lab

**M04-LAB09: NEED TO CHANGE SIGNAL NAME #366 **

## Related Issue

**Link related Github Issue** 🢂 Fixes #366  

## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [x] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#reporting-issues) 📝
- [x] Tested it
- [x] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝

Changes proposed in this pull request:

- Fixing the **signal name** when searching **Failed Requests** under  **create an alert rule** -> **conditions** 
