### PR TITLE
Resource group creation step was needed

### DIFF
--- a/Instructions/Labs/AZ400_M06_L12_Azure_Deployments_Using_Resource_Manager_Templates.md
+++ b/Instructions/Labs/AZ400_M06_L12_Azure_Deployments_Using_Resource_Manager_Templates.md
@@ -228,18 +228,8 @@ In this task, you will modify the main template to reference the template module
 5. Follow the same steps to upload the **C:\\templates\\storage.bicep** file too.
 6. From a **Bash** session in the Cloud Shell pane, run the following to perform a deployment by using a newly uploaded template:
 
-   ```bash
-   az deployment group what-if --name az400m06l15deployment --resource-group az400m06l15-RG --template-file main.bicep
-   ```
-
-7. When prompted to provide the value for 'adminUsername', type **Student** and press the **Enter** key.
-8. When prompted to provide the value for 'adminPassword', type **Pa55w.rd1234** and press the **Enter** key. (Password typing will not be shown)
-9. Review the result of this command which validates your deployment and let's you know if there is any errors in your templates. This is very valuable especially when deploying templates with many resources and in business critical cloud environments.
-
-10. From a **Bash** session in the Cloud Shell pane, run the following to perform a deployment by using a newly uploaded template:
-
        ```bash
-       LOCATION='<region>'
+       LOCATION='eastus'
        ```
 
        > **Note**: replace the name of the region with a region close to your location. If you do not know what locations are available, run the `az account list-locations -o table` command.
@@ -247,6 +237,16 @@ In this task, you will modify the main template to reference the template module
        ```bash
        az group create --name az400m06l15-RG --location $LOCATION
        ```
+       
+       ```bash
+       az deployment group what-if --name az400m06l15deployment --resource-group az400m06l15-RG --template-file main.bicep
+       ```
+
+7. When prompted to provide the value for 'adminUsername', type **Student** and press the **Enter** key.
+8. When prompted to provide the value for 'adminPassword', type **Pa55w.rd1234** and press the **Enter** key. (Password typing will not be shown)
+9. Review the result of this command which validates your deployment and let's you know if there is any errors in your templates. This is very valuable especially when deploying templates with many resources and in business critical cloud environments.
+
+10. From a **Bash** session in the Cloud Shell pane, run the following to perform a deployment by using a newly uploaded template:
 
        ```bash
        az deployment group create --name az400m06l15deployment --resource-group az400m06l15-RG --template-file main.bicep


### PR DESCRIPTION
The instruction where 'az deployment group what-if --name az400m06l15deployment --resource-group az400m06l15-RG --template-file main.bicep' command was executed was requiring a resource group to be present already. Since it is missing, this command caused error. Hence changed the place of the command to overcome this error.

**Replace issue name LAB00:QUICK_DESCRIPTION, for example "LAB01: My new issue" (or same name as linked Issue)**

## Related Issue

**Link related Github Issue** 🢂 Fixes # . (Include issue number after #)

## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [ ] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#reporting-issues) 📝
- [x] Tested it
- [x] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝

Changes proposed in this pull request:

-
-
-
