### PR TITLE
M03-LAB04: Replace .Net 6 reference with .Net only

### DIFF
--- a/Instructions/Labs/AZ400_M03_L04_Enabling_Continuous_Integration_with_Azure_Pipelines.md
+++ b/Instructions/Labs/AZ400_M03_L04_Enabling_Continuous_Integration_with_Azure_Pipelines.md
@@ -54,7 +54,7 @@ In this task you will import the eShopOnWeb Git repository that will be used by 
     - **.devcontainer** folder container setup to develop using containers (either locally in VS Code or GitHub Codespaces).
     - **.azure** folder contains Bicep & ARM infrastructure as code templates used in some lab scenarios.
     - **.github** folder contains YAML GitHub workflow definitions.
-    - **src** folder contains the .NET 6 website used in the lab scenarios.
+    - **src** folder contains the .NET website used in the lab scenarios.
 
 ### Exercise 1: Include build validation as part of a Pull Request
 


### PR DESCRIPTION
**M03-LAB04: Replace .Net 6 reference with .Net only**

## Related Issue

M03-LAB04: Replace .Net 6 reference with .Net only #472

## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [x] Has related GitHub Issue 💥 #472
- [x] Tested it
- [x] Read the PR collaboration guide

Changes proposed in this pull request:

- Replace .Net 6 reference with .Net only
