### PR TITLE
LAB_M03_L05: The development environment already exists in the original repo

### DIFF
--- a/Instructions/Labs/AZ400_M03_L05_Implementing_GitHub_Actions_for_CI_CD.md
+++ b/Instructions/Labs/AZ400_M03_L05_Implementing_GitHub_Actions_for_CI_CD.md
@@ -158,6 +158,9 @@ In this task, you will use GitHub environments to ask for manual approval before
 
 3. On the repository page, go to **Settings**, open **Environments** and click **New environment**.
 4. Give it **Development** name and click on **Configure Environment**.
+
+    > NOTE: If an environment called **Development** already exists in the **Environments** list, open its configuration by clicking on the environment name.  
+    
 5. In the **Configure Development** tab, check the option **Required Reviewers** and your GitHub account as a reviewer. Click on **Save protection rules**.
 6. Now lets test the protection rule. On the repository page, go to **Actions**, click on **eShopOnWeb Build and Test** workflow and click on **Run workflow>Run workflow** to execute manually.
 


### PR DESCRIPTION
## Related Issue
It is not related to an issue.

## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [ ] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#reporting-issues) 📝
- [X] Tested it
- [X] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝

Changes proposed in this pull request:

LAB M03_L05: the students find the development environments already created in the environment list. I added a note to explain them that if the environment is already there, they simply need to configure it.

