### PR TITLE
LAB00 - Enable classic pipeline creation for the Organization

### DIFF
--- a/Instructions/Labs/AZ400_M00_Validate_lab_environment.md
+++ b/Instructions/Labs/AZ400_M00_Validate_lab_environment.md
@@ -29,15 +29,15 @@ lab:
 1. At the **Organization settings** screen click **Billing** (opening this screen takes a few seconds).
 1. Click **Setup billing** and on the right-hand side of the screen select the **Azure Pass - Sponsorship** subscription and click **Save** to link the subscription with the organization.
 1. Once the screen shows the linked Azure Subscription ID at the top, change the number of **Paid parallel jobs** for **MS Hosted CI/CD** from 0 to **1**. Then click the **SAVE** button at the bottom.
-2. In **Organization Settings**, go to section **Pipelines** and click **Settings**.
-3. Toggle the switch to **Off** for **Disable creation of classic build pipelines** and **Disable creation of classic release pipelines**
+1. In **Organization Settings**, go to section **Pipelines** and click **Settings**.
+1. Toggle the switch to **Off** for **Disable creation of classic build pipelines** and **Disable creation of classic release pipelines**
     > Note: The **Disable creation of classic release pipelines** switch sets to **On** hides classic release pipeline creation options such as the **Release** menu in the **Pipeline** section of DevOps projects.
-4. In **Organization Settings**, go to section **Security** and click **Policies**.
-5. Toggle the switch to **On** for **Third-party application access via OAuth**
+1. In **Organization Settings**, go to section **Security** and click **Policies**.
+1. Toggle the switch to **On** for **Third-party application access via OAuth**
     > Note: The OAuth setting helps enable tools such as the DemoDevOpsGenerator to register extensions. Without this, several labs may fail due to a lack of the required extensions.
-6. Toggle the switch to **On** for **Allow public projects**
+1. Toggle the switch to **On** for **Allow public projects**
     > Note: Extensions used in some labs might require a public project to allow using the free version.
-7. **Wait at least 3 hours before using the CI/CD capabilities** so that the new settings are reflected in the backend. Otherwise, you will still see the message *"No hosted parallelism has been purchased or granted"*.
+1. **Wait at least 3 hours before using the CI/CD capabilities** so that the new settings are reflected in the backend. Otherwise, you will still see the message *"No hosted parallelism has been purchased or granted"*.
 
 ## Instructions to create the sample Azure DevOps Project (you only have to do this once)
 

--- a/Instructions/Labs/AZ400_M00_Validate_lab_environment.md
+++ b/Instructions/Labs/AZ400_M00_Validate_lab_environment.md
@@ -29,12 +29,15 @@ lab:
 1. At the **Organization settings** screen click **Billing** (opening this screen takes a few seconds).
 1. Click **Setup billing** and on the right-hand side of the screen select the **Azure Pass - Sponsorship** subscription and click **Save** to link the subscription with the organization.
 1. Once the screen shows the linked Azure Subscription ID at the top, change the number of **Paid parallel jobs** for **MS Hosted CI/CD** from 0 to **1**. Then click the **SAVE** button at the bottom.
-1. In **Organization Settings**, go to section **Security** and click **Policies**.
-1. Toggle the switch to **On** for **Third-party application access via OAuth**
+2. In **Organization Settings**, go to section **Pipelines** and click **Settings**.
+3. Toggle the switch to **Off** for **Disable creation of classic build pipelines** and **Disable creation of classic release pipelines**
+    > Note: The **Disable creation of classic release pipelines** switch sets to **On** hides classic release pipeline creation options such as the **Release** menu in the **Pipeline** section of DevOps projects.
+4. In **Organization Settings**, go to section **Security** and click **Policies**.
+5. Toggle the switch to **On** for **Third-party application access via OAuth**
     > Note: The OAuth setting helps enable tools such as the DemoDevOpsGenerator to register extensions. Without this, several labs may fail due to a lack of the required extensions.
-1. Toggle the switch to **On** for **Allow public projects**
+6. Toggle the switch to **On** for **Allow public projects**
     > Note: Extensions used in some labs might require a public project to allow using the free version.
-1. **Wait at least 3 hours before using the CI/CD capabilities** so that the new settings are reflected in the backend. Otherwise, you will still see the message *"No hosted parallelism has been purchased or granted"*.
+7. **Wait at least 3 hours before using the CI/CD capabilities** so that the new settings are reflected in the backend. Otherwise, you will still see the message *"No hosted parallelism has been purchased or granted"*.
 
 ## Instructions to create the sample Azure DevOps Project (you only have to do this once)
 


### PR DESCRIPTION
The pull request is not related to an issue

## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [ ] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#reporting-issues) 📝
- [X] Tested it
- [X] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝

Changes proposed in this pull request:
The new organizations are created with the switches "Disable creation of classic build pipelines" and "Disable creation of classic release pipelines" set to on. It means that the students cannot create classic pipelines (build and release) and the options to create them (for example the Release option in the Pipeline in a project) will be not visible.
The students need to create those kind of pipeline in the labs and they need the option.