### PR TITLE
LAB10 - Ui changes for new service connection and a typo

### DIFF
--- a/Instructions/Labs/AZ400_M05_L10_Integrating_Azure_Key_Vault_with_Azure_DevOps.md
+++ b/Instructions/Labs/AZ400_M05_L10_Integrating_Azure_Key_Vault_with_Azure_DevOps.md
@@ -118,7 +118,7 @@ A Service Principal is automatically created by Azure Pipelines, when you connec
 
 7. On the **New service connection** blade, select **Azure Resource Manager** and **Next** (may need to scroll down).
 
-8. The choose **Service Principal (manual)** and click on **Next**.
+8. Then choose **Service Principal (manual)** and click on **Next**.
 
 9. Fill in the empty fields using the information gathered during previous steps:
     - Subscription Id and Name.

--- a/Instructions/Labs/AZ400_M05_L10_Integrating_Azure_Key_Vault_with_Azure_DevOps.md
+++ b/Instructions/Labs/AZ400_M05_L10_Integrating_Azure_Key_Vault_with_Azure_DevOps.md
@@ -114,6 +114,8 @@ A Service Principal is automatically created by Azure Pipelines, when you connec
 
     ![New Service Connection](images/new-service-connection.png)
 
+    > **Note**: If there are no Service Connections previously created on the page, the service connection creation button is located in the center of the page and has the label **Create service connection**
+
 7. On the **New service connection** blade, select **Azure Resource Manager** and **Next** (may need to scroll down).
 
 8. The choose **Service Principal (manual)** and click on **Next**.


### PR DESCRIPTION
This pull request is not related to an issue

## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [ ] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#reporting-issues) 📝
- [X] Tested it
- [X] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝

Changes proposed in this pull request:

- LAB 10 - EX 01 - TASK 01 - STEP 06: In the Service Connections page, if you don't have any connections previously created, the command to create a new service connection is not on top on the page, but in the center and the label is "Create service connection"
-LAB 10 - EX 01 - TASK 01 - STEP 08 : there is a typo here (probably). The word "the" must be "then" 
-
