### PR TITLE
Update AZ400_M05_L10_Integrating_Azure_Key_Vault_with_Azure_DevOps.md

### DIFF
--- a/Instructions/Labs/AZ400_M05_L10_Integrating_Azure_Key_Vault_with_Azure_DevOps.md
+++ b/Instructions/Labs/AZ400_M05_L10_Integrating_Azure_Key_Vault_with_Azure_DevOps.md
@@ -158,7 +158,7 @@ In this task, you will import an existing CI YAML pipeline definition, modify an
 
     ![Container Images in ACR](images/azure-container-registry.png)
 
-1. Click on **Access Keys**, enable the **Admin user** if not done already and copy the **password** value, it will be used in the following task, as we will keep it as a secret  in Azure Key Vault.
+1. Click on **Access Keys**, enable the **Admin user** if not done already, and copy the **password** value. It will be used in the following task, as we will keep it as secret in Azure Key Vault.
 
     ![ACR password](images/acr-password.png)
 

--- a/Instructions/Labs/AZ400_M05_L10_Integrating_Azure_Key_Vault_with_Azure_DevOps.md
+++ b/Instructions/Labs/AZ400_M05_L10_Integrating_Azure_Key_Vault_with_Azure_DevOps.md
@@ -158,7 +158,7 @@ In this task, you will import an existing CI YAML pipeline definition, modify an
 
     ![Container Images in ACR](images/azure-container-registry.png)
 
-1. Click on **Access Keys** and copy the **password** value, it will be used in the following task, as we will keep it as a secret  in Azure Key Vault.
+1. Click on **Access Keys**, enable the **Admin user** if not done already and copy the **password** value, it will be used in the following task, as we will keep it as a secret  in Azure Key Vault.
 
     ![ACR password](images/acr-password.png)
 


### PR DESCRIPTION
Added a missing step to enable the admin user first before copying the password value

## Related Issue

**Link related Github Issue** 🢂 Fixes #554 

## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [X] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#reporting-issues) 📝
- [X] Tested it
- [X] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝

Changes proposed in this pull request:

- Adding a note to enable Admin user first
-
-
