### PR TITLE
LAB01: Added user search for work item assignment

### DIFF
--- a/Instructions/Labs/AZ400_M01_L01_Agile_Planning_and_Portfolio_Management_with_Azure_Boards.md
+++ b/Instructions/Labs/AZ400_M01_L01_Agile_Planning_and_Portfolio_Management_with_Azure_Boards.md
@@ -125,7 +125,7 @@ Work items play a prominent role in Azure DevOps. Whether describing work to be 
     ![In the "Boards">"Work Items" window, click on "New work item" >Epic](images/m1/EShop-WEB-create_epic_v1.png)
 
 1. In the **Enter title** textbox, type **Product training**.
-1. In the upper left corner, select the **Unassigned** entry and, in the dropdown list, select your user account in order to assign the new work item to yourself.
+1. In the upper left corner, select the **Unassigned** entry and, in the dropdown list, select your user account in order to assign the new work item to yourself. If your name doesn't appear to start with, begin typing your name and click **Search**.
 1. Next to the **Area** entry, select the **eShopOnWeb** entry and, in the dropdown list, select **EShop-WEB**. This will set the **Area** to **eShopOnWeb\EShop-WEB**.
 1. Next to the **Iteration** entry, select the **eShopOnWeb** entry and, in the dropdown list, select **Sprint 2**. This will set the **Iteration** to **eShopOnWeb\Sprint 2**.
 1. Click **Save** to finalize your changes. **Do not close it**.


### PR DESCRIPTION
When following the instructions to assign the first work item to yourself, the drop-down won't initially show your name the first time you try, so you have to search and select your name.

## Related Issue 

**Link related Github Issue** 🢂 Fixes #561 

## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [x] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#reporting-issues) 📝
- [x] Tested it
- [x] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝

Changes proposed in this pull request:

- Added a short sentence to explain that you might have to search for the user account the first time you try to assign a work item.
