### PR TITLE
M04_L11: A YAML pipeline will re-create a deleted resource group if the pipeline is left in place when done

### DIFF
--- a/Instructions/Labs/AZ400_M04_L11_Enable_Dynamic_Configuration_and_Feature_Flags.md
+++ b/Instructions/Labs/AZ400_M04_L11_Enable_Dynamic_Configuration_and_Feature_Flags.md
@@ -175,7 +175,7 @@ Let's continue to test the Feature manager.
 1. You can disable this feature in App Configuration and then you would see that the image disappears.
 
    > [!IMPORTANT]
-   > Remember to delete the resources created in the Azure portal to avoid unnecessary charges.
+   > Remember to delete the resources created in the Azure portal to avoid unnecessary charges. Be sure to disable the **eshoponweb-cd-webapp-code** pipeline or it will re-create a deleted resource group and associated resources after the next run of **eshoponweb-ci**.
 
 ## Review
 


### PR DESCRIPTION
If following along to AZ400_M04_L12 the eshoponweb-ci pipeline will trigger eshoponweb-cd-webapp-code which creates the target resource group, even if it was deleted.

## Related Issue

🢂 Fixes #612 . (Include issue number after #)

## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [x] Has related GitHub Issue
- [x] Tested it
- [x] Read the PR collaboration guide

Changes proposed in this pull request:

- Update documentation to provide a specific reminder to disable a pipeline that will rebuild deleted resource groups and resources
