### PR TITLE
M03_L08-EX01-Step04: Missing <region> placeholder in the bash scripts

### DIFF
--- a/Instructions/Labs/AZ400_M03_L08_Control_Deployments_using_Release_Gates.md
+++ b/Instructions/Labs/AZ400_M03_L08_Control_Deployments_using_Release_Gates.md
@@ -121,7 +121,7 @@ In this task, you will create two Azure web apps representing the **DevTest** an
    > **Note**: possible locations can be found by running the following command, use the **Name** on `<region>` : `az account list-locations -o table`
 
    ```bash
-   REGION='centralus'
+   REGION='<region>'
    RESOURCEGROUPNAME='az400m03l08-RG'
    az group create -n $RESOURCEGROUPNAME -l $REGION
    ```


### PR DESCRIPTION
## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [ ] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#reporting-issues) 📝
- [X] Tested it
- [X] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝

Changes proposed in this pull request:

- M03_LAB08: Ex01-Step04: In the instructions is mentioned <region> placeholder but there isn't any <region> placeholder in the bash scripts. Added
