### PR TITLE
Trivial Fix: A resource group reference named after a prior name was left in place

### DIFF
--- a/Instructions/Labs/AZ400_M08_L14_Monitor_Application_Performance_with_Azure_Load_Testing.md
+++ b/Instructions/Labs/AZ400_M08_L14_Monitor_Application_Performance_with_Azure_Load_Testing.md
@@ -397,7 +397,7 @@ Perform the following steps to download the input files for an existing load tes
           inputs:
             azureSubscription: 'AZURE DEMO SUBSCRIPTION'
             loadTestConfigFile: '$(Build.SourcesDirectory)/tests/jmeter/config.yaml'
-            resourceGroup: 'az400m05l11-RG'
+            resourceGroup: 'az400m08l14-RG'
             loadTestResource: 'eShopOnWebLoadTesting'
             loadTestRunName: 'ado_run'
             loadTestRunDescription: 'load testing from ADO'


### PR DESCRIPTION
Found a typo left over from a prior rename. This results in:

```
##[error]The Azure Load Testing resource eShopOnWebLoadTesting does not exist. Please provide an existing resource.
```

## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [ ] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#reporting-issues) 📝
- [x] Tested it
- [x] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝

Changes proposed in this pull request:

- Change the resource group reference in the Load Test task to refer to the new name of the recently renamed resource group
