### PR TITLE
631-M01-LAB01: Correct typo and wrongly escaped text in Definition of Done text

### DIFF
--- a/Instructions/Labs/AZ400_M01_L01_Agile_Plan_and_Portfolio_Management_with_Azure_Boards.md
+++ b/Instructions/Labs/AZ400_M01_L01_Agile_Plan_and_Portfolio_Management_with_Azure_Boards.md
@@ -375,7 +375,7 @@ To maximize a team's ability to consistently deliver high quality software, Kanb
 
     > **Note**: As your team updates the status of work as it progresses from one stage to the next, it helps that they agree on what **done** means. By specifying the **Definition of done** criteria for each Kanban column, you help share the essential tasks to complete before moving an item into a downstream stage.
 
-1. On the **QA Approved** tab, at the bottom of the panel, in the **Definition of done** textbox, type **`Passes \*\*all\*\* tests`**.
+1. On the **QA Approved** tab, at the bottom of the panel, in the **Definition of done** textbox, type **`Passes **all** tests`**.
 1. Click **Save** to save and close the settings.
 
     ![Screenshot of the settings split column and definition of done configuration.](images/m1/dd_v1.png)

--- a/Instructions/Labs/AZ400_M01_L01_Agile_Plan_and_Portfolio_Management_with_Azure_Boards.md
+++ b/Instructions/Labs/AZ400_M01_L01_Agile_Plan_and_Portfolio_Management_with_Azure_Boards.md
@@ -299,7 +299,7 @@ The sprint backlog should contain all the information the team needs to successf
 
     > **Note**: This applies to capacity and burndown calculations.
 
-1. In the **Settings** panel, select the **General** tab, and under the **Working with bugs** section you can sepcify how you manage bugs in backlogs and boards.
+1. In the **Settings** panel, select the **General** tab, and under the **Working with bugs** section you can specify how you manage bugs in backlogs and boards.
 
     > **Note**: Entries on this tab allow you to specify how bugs are presented on the board.
 


### PR DESCRIPTION
## Related Issue

**Link related Github Issue** 🢂 Fixes #631 

## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [X] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#reporting-issues) 📝
- [X] Tested it
- [X] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝

Changes proposed in this pull request:

- Change `sepcify` into `specify`
- Remove unnecessary escaping with backslashes in code block for asterisks
