### PR TITLE
LAB04 : EX02-TASK02-STEP03: The button label to save the pipeline is "Validate and save" instead "Save"

### DIFF
--- a/Instructions/Labs/AZ400_M02_L04_Enable_Continuous_Integration_with_Azure_Pipelines.md
+++ b/Instructions/Labs/AZ400_M02_L04_Enable_Continuous_Integration_with_Azure_Pipelines.md
@@ -168,7 +168,7 @@ The default build pipeline definition doesn't enable Continuous Integration.
 
     Since you enabled Branch Policies, you need to pass by a Pull Request in order to update your code.
 
-1. Click the **Save** button (not **Save and run**) to save the pipeline definition.
+1. Click the **Validate and save** button to validate and save the pipeline definition.
 1. Select **Create a new branch for this commit**.
 1. Keep the default branch name and **Start a pull request** checked.
 1. Click on **Save**.


### PR DESCRIPTION
## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [ ] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#reporting-issues) 📝
- [X] Tested it
- [X] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝

Changes proposed in this pull request:
This pull request includes a change to the instructions for enabling Continuous Integration in Azure Pipelines. The change updates the button name to reflect the current UI.

* [`Instructions/Labs/AZ400_M02_L04_Enable_Continuous_Integration_with_Azure_Pipelines.md`](diffhunk://#diff-864e4acfee9343a4ecf14e14333d20aa7979fc7b5d45cf4c5d0da23a3f4dcea0L171-R171): Updated the button name from "Save" to "Validate and save" to ensure accuracy with the current Azure Pipelines interface.

![image](https://github.com/user-attachments/assets/9f352595-1df4-4dcf-95d2-ef8ee4dceaa6)
