### PR TITLE
Lab13 fix for some issues

### DIFF
--- a/Instructions/Labs/AZ400_M07_L13_Package_Management_with_Azure_Artifacts.md
+++ b/Instructions/Labs/AZ400_M07_L13_Package_Management_with_Azure_Artifacts.md
@@ -194,7 +194,7 @@ Besides developing your own packages, why not using the Open Source NuGet (<http
 
 In this task, we will use a generic "Newtonsoft.Json" sample package, but you can use the same approach for other packages in the library.
 
-1. From the same PowerShell window used in the previous task to push the new package, navigate back to the **eShopOnWeb.Shared** folder (`cd..`), and run the following **dotnet** command to install the sample package:
+1. From the same PowerShell window used in the previous task to push the new package, navigate back to the **eShopOnWeb.Shared** folder (`cd ../..`), and run the following **dotnet** command to install the sample package:
 
    ```powershell
    dotnet add package Newtonsoft.Json

--- a/Instructions/Labs/AZ400_M07_L13_Package_Management_with_Azure_Artifacts.md
+++ b/Instructions/Labs/AZ400_M07_L13_Package_Management_with_Azure_Artifacts.md
@@ -171,7 +171,7 @@ In this task, you will create and publish an in-house developed custom NuGet pac
 1. Run the following to publish the package to the **eShopOnWebShared** feed. Replace the source with the URL you copied earlier from the Visual Studio **Source** url `https://pkgs.dev.azure.com/Azure-DevOps-Org-Name/_packaging/eShopOnWebShared/nuget/v3/index.json`
 
    ```powershell
-   dotnet nuget push --source "https://pkgs.dev.azure.com/Azure-DevOps-Org-Name/_packaging/eShopOnWebShared/nuget/v3/index.json" --api-key az "eShopOnWeb.Shared.1.0.0.nupkg"
+   dotnet nuget push --source "https://pkgs.dev.azure.com/Azure-DevOps-Org-Name/_packaging/eShopOnWebShared/nuget/v3/index.json" --api-key az "eShopOnWeb-XXXXXX.Shared.1.0.0.nupkg"
    ```
 
    > **Important**: You need to install the credential provider for your operating system to be able to authenticate with Azure DevOps. You can find the installation instructions at [Azure Artifacts Credential Provider](https://go.microsoft.com/fwlink/?linkid=2099625). You can install by running the following command in the PowerShell window: `iex "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) } -AddNetfx"`

--- a/Instructions/Labs/AZ400_M07_L13_Package_Management_with_Azure_Artifacts.md
+++ b/Instructions/Labs/AZ400_M07_L13_Package_Management_with_Azure_Artifacts.md
@@ -174,7 +174,7 @@ In this task, you will create and publish an in-house developed custom NuGet pac
    dotnet nuget push --source "https://pkgs.dev.azure.com/Azure-DevOps-Org-Name/_packaging/eShopOnWebShared/nuget/v3/index.json" --api-key az "eShopOnWeb-XXXXXX.Shared.1.0.0.nupkg"
    ```
 
-   > **Important**: You need to install the credential provider for your operating system to be able to authenticate with Azure DevOps. You can find the installation instructions at [Azure Artifacts Credential Provider](https://go.microsoft.com/fwlink/?linkid=2099625). You can install by running the following command in the PowerShell window: `iex "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) } -AddNetfx"`
+   > **Important**: If you receive and authorization error (401 Unauthorized), you need to install the credential provider for your operating system to be able to authenticate with Azure DevOps. You can find the installation instructions at [Azure Artifacts Credential Provider](https://go.microsoft.com/fwlink/?linkid=2099625). You can install by running the following command in the PowerShell window: `iex "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) } -AddNetfx"`
 
    > **Note**: You need to provide an **API Key**, which can be any non-empty string. We're using **az** here. When prompted, sign in to your Azure DevOps organization.
 


### PR DESCRIPTION
This pull request updates the instructions for managing NuGet packages in Azure Artifacts to improve clarity and accuracy. The most important changes include modifying the package name and fixing navigation commands, as well as adding details to handle potential authorization errors.

### Updates to NuGet package publishing:

* Updated the package name in the `dotnet nuget push` command to reflect a more specific naming convention (`eShopOnWeb-XXXXXX.Shared.1.0.0.nupkg` instead of `eShopOnWeb.Shared.1.0.0.nupkg`).

* Added a clarification about handling "401 Unauthorized" errors by installing the Azure Artifacts Credential Provider. This provides better guidance for users encountering authentication issues.

### Navigation and installation instructions:

* Corrected the navigation command in the PowerShell instructions to ensure users navigate back two levels (`cd ../..`) instead of one (`cd..`) when returning to the `eShopOnWeb.Shared` folder.

## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [ ] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#reporting-issues) 📝
- [X] Tested it
- [X] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝

