### PR TITLE
LAB13-EX01-STEP03: Added detailed instructions to select the C# project that targets .NET or .NET standard

### DIFF
--- a/Instructions/Labs/AZ400_M07_L13_Package_Management_with_Azure_Artifacts.md
+++ b/Instructions/Labs/AZ400_M07_L13_Package_Management_with_Azure_Artifacts.md
@@ -125,7 +125,7 @@ In this task, you will create and publish an in-house developed custom NuGet pac
 
    > **Note**: We will now create a shared assembly that will be published as a NuGet package so that other teams can integrate it and stay up to date without having to work directly with the project source.
 
-1. On the **Recent project templates** page of the **Create a new project** pane, use the search textbox to locate the **Class Library** template, select the template for C#, and click **Next**.
+1. In the **Create a new project** pane, use the search textbox to locate the **Class Library** template, select the template for C# that targets .NET or .NET Standard, and click **Next**.
 1. On the **Class Library** page of the **Create a new project** pane, specify the following settings and click **Create**:
 
    | Setting       | Value                    |


### PR DESCRIPTION
This pull request includes a small update to the instructions for creating a new project in the `AZ400_M07_L13_Package_Management_with_Azure_Artifacts.md` file. The change clarifies that the `Class Library` template should target .NET or .NET Standard.

## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [ ] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#reporting-issues) 📝
- [X] Tested it
- [X] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝
