### PR TITLE
LAB00 - Clarify instructions regarding the "Grant access permission to all pipelines" option in Azure DevOps service connection setup

### DIFF
--- a/Instructions/Labs/AZ400_M00_Validate_lab_environment.md
+++ b/Instructions/Labs/AZ400_M00_Validate_lab_environment.md
@@ -152,7 +152,9 @@ You will need to create a service connection in Azure DevOps which will allow yo
 
 1. Make sure the **Grant access permission to all pipelines** option is unchecked and select **Save**.
 
-   > **Important:** The **Grant access permission to all pipelines** option is not recommended for production environments. It is only used in this lab to simplify the configuration of the pipeline.
+   > **Important:** The **Grant access permission to all pipelines** option is not recommended for production environments: selecting the option means granting access to the service connection to all pipelines in the project, not selecting the option allows you to approve the access to the service connection on the first run of each pipeline.
+
+   > **Note**: If the **Grant access permission to all pipelines** option is disabled (it is in gray) and cannot be changed, continue with the lab.
 
    > **Note**: If you see an error message indicating you don't have the necessary permissions to create a service connection, try again, or configure the service connection manually.
 


### PR DESCRIPTION
This pull request updates the instructions for configuring a service connection in Azure DevOps to provide additional clarity about the "Grant access permission to all pipelines" option and to address a potential issue with the option being disabled.

Improvements to instructions:

* Clarified the implications of selecting or not selecting the **Grant access permission to all pipelines** option, explaining how it affects access to the service connection.
* Added guidance for cases where the **Grant access permission to all pipelines** option is disabled and cannot be changed, instructing users to proceed with the lab regardless.

## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [ ] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#reporting-issues) 📝
- [X] Tested it
- [X] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝

