### PR TITLE
LAB13: Fix typo placeholder in dotnet pack command for NuGet package creation

### DIFF
--- a/Instructions/Labs/AZ400_M07_L13_Package_Management_with_Azure_Artifacts.md
+++ b/Instructions/Labs/AZ400_M07_L13_Package_Management_with_Azure_Artifacts.md
@@ -153,7 +153,7 @@ In this task, you will create and publish an in-house developed custom NuGet pac
 1. Run the following to create a **.nupkg** file from the project (change the value of `XXXXXX` placeholder with a unique string).
 
    ```powershell
-   dotnet pack .\eShopOnWeb.Shared.csproj -p:PackageId=eShopOnWeb-XXXXX.Shared
+   dotnet pack .\eShopOnWeb.Shared.csproj -p:PackageId=eShopOnWeb-XXXXXX.Shared
    ```
 
    > **Note**: The **dotnet pack** command builds the project and creates a NuGet package in the **bin\Release** folder. If you don't have a **Release** folder, you can use the **Debug** folder instead.


### PR DESCRIPTION
This pull request includes a minor correction to the `Instructions/Labs/AZ400_M07_L13_Package_Management_with_Azure_Artifacts.md` file. The change ensures consistency in the placeholder value for the `PackageId` parameter in the `dotnet pack` command. 

* [`Instructions/Labs/AZ400_M07_L13_Package_Management_with_Azure_Artifacts.md`](diffhunk://#diff-3573b2705dcfb4d03dc2951426d433c481984fde784f83382fc88ec5cba51558L156-R156): Updated the placeholder `XXXXX` to `XXXXXX` in the `dotnet pack` command to match the instructions.

## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [ ] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#reporting-issues) 📝
- [X] Tested it
- [X] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝
