### PR TITLE
LAB12-EX01-TASK03: Clarify task description in lab instructions to specify the use of the simple-windows-vm template

### DIFF
--- a/Instructions/Labs/AZ400_M05_L12_Deployments_using_Azure_Bicep_templates.md
+++ b/Instructions/Labs/AZ400_M05_L12_Deployments_using_Azure_Bicep_templates.md
@@ -138,9 +138,9 @@ In this task, you will create a storage template module **storage.bicep** which 
    output storageURI string = storageAccount.properties.primaryEndpoints.blob
    ```
 
-#### Task 3: Modify the main template to use the template module
+#### Task 3: Modify the simple-windows-vm template to use the template module
 
-In this task, you will modify the main template to reference the template module you created in the previous task.
+In this task, you will modify the `simple-windows-vm.bicep` template to reference the template module you created in the previous task.
 
 1. Navigate back to the `simple-windows-vm.bicep` file and click on the **Edit** button once again.
 


### PR DESCRIPTION
This pull request includes a minor update to the instructions for deploying Azure Bicep templates. The change clarifies the task description by specifying the `simple-windows-vm.bicep` template instead of the generic "main template."

## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [ ] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#reporting-issues) 📝
- [x] Tested it
- [ ] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝
