### PR TITLE
Fix typos in Azure DevOps lab instructions

### DIFF
--- a/Instructions/Labs/AZ400_M01_L02_Version_Control_with_Git_in_Azure_Repos.md
+++ b/Instructions/Labs/AZ400_M01_L02_Version_Control_with_Git_in_Azure_Repos.md
@@ -107,7 +107,7 @@ In this exercise, you will use Visual Studio Code to commit changes to the **mai
 
 In this task, you will step through the process of cloning a Git repository by using Visual Studio Code.
 
-1. Switch to the the web browser displaying your Azure DevOps organization with the **eShopOnWeb** project you generated in the previous exercise.
+1. Switch to the web browser displaying your Azure DevOps organization with the **eShopOnWeb** project you generated in the previous exercise.
 1. In the vertical navigational pane of the Azure DevOps portal, select the **Repos** icon.
 
 1. In the upper right corner of the **eShopOnWeb** repository pane, click **Clone**.
@@ -314,7 +314,7 @@ For simplicity we will work directly on the web browser repo editor (working dir
 
 In this task, you will use the Azure DevOps portal to test the policy and create your first Pull Request.
 
-1. In the vertical navigational pane of the of the Azure DevOps portal, in the **Repos>Files**, make sure the **main** branch is selected (dropdown above shown content).
+1. In the vertical navigational pane of the Azure DevOps portal, in the **Repos>Files**, make sure the **main** branch is selected (dropdown above shown content).
 1. To make sure policies are working, try making a change and committing it on the **main** branch, navigate to the **/eShopOnWeb/src/Web/Program.cs** file and select it. This will automatically display its content in the details pane.
 1. On the first line add the following comment:
 
@@ -332,9 +332,9 @@ In this task, you will use the Azure DevOps portal to test the policy and create
 
 In this task, you will use the Azure DevOps portal to create a Pull Request, using the **dev** branch to merge a change into the protected **main** branch. An Azure DevOps work item will be linked to the changes to be able to trace pending work with code activity.
 
-1. In the vertical navigational pane of the of the Azure DevOps portal, in the **Boards** section, select **Work Items**.
+1. In the vertical navigational pane of the Azure DevOps portal, in the **Boards** section, select **Work Items**.
 1. Click on **+ New Work Item > Product Backlog Item**. In title field, write **Testing my first PR** and click on **Save**.
-1. Now go back to the vertical navigational pane of the of the Azure DevOps portal, in the **Repos>Files**, make sure the **dev** branch is selected.
+1. Now go back to the vertical navigational pane of the Azure DevOps portal, in the **Repos>Files**, make sure the **dev** branch is selected.
 1. Navigate to the **/eShopOnWeb/src/Web/Program.cs** file and make the following change on the first line:
 
     ```csharp
@@ -368,7 +368,7 @@ In this task, you will use the Azure DevOps portal to create a Pull Request, usi
 
 The product team has decided that the current version of the site should be released as v1.1.0-beta.
 
-1. In the vertical navigational pane of the of the Azure DevOps portal, in the **Repos** section, select **Tags**.
+1. In the vertical navigational pane of the Azure DevOps portal, in the **Repos** section, select **Tags**.
 1. In the **Tags** pane, click **New tag**.
 1. In the **Create a tag** panel, in the **Name** text box, type **`v1.1.0-beta`**, in the **Based on** drop-down list leave the **main** entry selected, in the **Description** text box, type **`Beta release v1.1.0`** and click **Create**.
 

--- a/Instructions/Labs/AZ400_M04_L10_Integrate_Azure_Key_Vault_with_Azure_DevOps.md
+++ b/Instructions/Labs/AZ400_M04_L10_Integrate_Azure_Key_Vault_with_Azure_DevOps.md
@@ -158,7 +158,7 @@ In this task, you will create a Variable Group in Azure DevOps that will retriev
 
 1. On your lab computer, start a web browser and navigate to the Azure DevOps project **eShopOnWeb**.
 
-1. In the vertical navigational pane of the of the Azure DevOps portal, select **Pipelines > Library**. Click on **+ Variable Group**.
+1. In the vertical navigational pane of the Azure DevOps portal, select **Pipelines > Library**. Click on **+ Variable Group**.
 
 1. On the **New variable group** blade, specify the following settings:
 


### PR DESCRIPTION
Fast typo fix.

https://microsoftlearning.github.io/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/Instructions/Labs/AZ400_M01_L02_Version_Control_with_Git_in_Azure_Repos.html

AZ400_M01_L02_Version_Control_with_Git_in_Azure_Repos.html

<img width="1405" height="883" alt="image" src="https://github.com/user-attachments/assets/d90430fa-bf43-4e33-80bf-6146fdfbb2bd" />


<img width="1530" height="1038" alt="image" src="https://github.com/user-attachments/assets/555aa92d-0522-424f-9a6a-4e8af2d3bdd8" />

