### PR TITLE
LAB03-EX01-TASK01-STEP06: Add note for selecting Windows Server 2022 Datacenter image in lab instructions

### DIFF
--- a/Instructions/Labs/AZ400_M02_L03_Configure_Agent_Pools_and_Understand_Pipeline_Styles.md
+++ b/Instructions/Labs/AZ400_M02_L03_Configure_Agent_Pools_and_Understand_Pipeline_Styles.md
@@ -99,6 +99,9 @@ In this exercise, you will create an Azure virtual machine (VM) and use it to cr
    | **Public inbound ports** section | Select **Allow selected ports**. |
    | **Select inbound ports** drop-down list | Select **RDP (3389)**. |
 
+
+   > **Note**: If the **Windows Server 2022 Datacenter: Azure Edition - x64 Gen2** image is not available in the list of images suggested by the portal, click on the **See all images** link, then, on the marketplace page, select the **Select** combo box for the **Windows Server** product and choose the right image.
+
 1. On the **Management** tab, in the **Identity** section, select the **Enable system assigned managed identity** checkbox and then select **Review + create**:
 
 1. On the **Review + create** tab, select **Create**.


### PR DESCRIPTION
This pull request adds an important clarification to the instructions for creating an Azure virtual machine, specifically addressing how to select the correct Windows Server image if it is not immediately visible in the portal.
In some subscriptions, the Windows Server images proposed by the portal are 2025 and not the 2022 mentioned in the instructions

Documentation improvement:

* Added a note explaining that if the `Windows Server 2022 Datacenter: Azure Edition - x64 Gen2` image is not listed, users should click **See all images** and use the marketplace's **Select** combo box to choose the appropriate image.

## Checklist 
Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:
- [ ] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#reporting-issues) 📝
- [X] Tested it
- [X] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/AZ400-DesigningandImplementingMicrosoftDevOpsSolutions/blob/master/.github/CONTRIBUTING.md#pull-requests) 📝
